### PR TITLE
Fix app window positioning when using larger heights

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -32,7 +32,7 @@
 
     NSRect visible = [[NSScreen mainScreen] visibleFrame];
     frame.origin.x = visible.size.width / 2 - frame.size.width / 2;
-    frame.origin.y = visible.size.height / 2 + frame.size.height / 2;
+    frame.origin.y = visible.size.height / 2 - frame.size.height / 2;
     NSLog(@"frame %@", NSStringFromRect(frame));
 
     _window = [[NSWindow alloc] initWithContentRect:frame


### PR DESCRIPTION
In the current version, increasing the height results in the window moving higher, which results in the grab-able part of the window moving outside of the screen. This occurs because the current calculation for the origin y value of the screen is calculated with the wrong sign. This PR fixes this :+1: 